### PR TITLE
Add top-level tabs inside the header

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "js-cookie": "^2.2.1",
     "node-sass": "^4.14.1",
     "normalize.css": "^8.0.1",
+    "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-copy-to-clipboard": "^5.0.2",
     "react-dom": "^16.13.1",

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -65,7 +65,7 @@ const App = () => {
           .reverse();
         setTerms(newTerms);
       });
-  });
+  }, [setTerms]);
 
   // Set the term to be the first one if it is unset
   // (once the terms load)

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -51,11 +51,10 @@ const App = () => {
   }, [term]);
 
   // Fetch all terms via the GitHub API
-  // TODO change to Bits of Good repo to fetch up-to-date terms
   useEffect(() => {
     axios
       .get(
-        'https://api.github.com/repos/64json/gt-schedule-crawler/contents?ref=gh-pages'
+        'https://api.github.com/repos/GTBitsOfGood/gt-schedule-crawler/contents?ref=gh-pages'
       )
       .then((res) => {
         const newTerms = res.data

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -1,23 +1,13 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import axios from 'axios';
-import { classes, isMobile } from '../../utils';
-import {
-  Button,
-  Calendar,
-  CombinationContainer,
-  CourseContainer,
-  Header
-} from '..';
+import { classes } from '../../utils';
+import { Header, Scheduler, Map, Comparison } from '..';
 import { Oscar } from '../../beans';
+import { useCookie, useJsonCookie, useMobile } from '../../hooks';
+import { TermContext, TermsContext, ThemeContext } from '../../contexts';
+
 import 'react-virtualized/styles.css';
 import './stylesheet.scss';
-import { useCookie, useJsonCookie } from '../../hooks';
-import {
-  OverlayCrnsContext,
-  TermContext,
-  TermsContext,
-  ThemeContext
-} from '../../contexts';
 
 const defaultTermData = {
   desiredCourses: [],
@@ -27,21 +17,18 @@ const defaultTermData = {
   sortingOptionIndex: 0
 };
 
-export function App(props) {
-  const [theme, setTheme] = useCookie('theme', 'dark');
-  const [term, setTerm] = useCookie('term');
-  const [termData, patchTermData] = useJsonCookie(term, defaultTermData);
+const App = () => {
   const [terms, setTerms] = useState([]);
   const [oscar, setOscar] = useState(null);
 
-  const [tabIndex, setTabIndex] = useState(0);
-  const [mobile, setMobile] = useState(isMobile());
-  const [overlayCrns, setOverlayCrns] = useState([]);
+  // Persist the theme, term, and some term data as cookies
+  const [theme, setTheme] = useCookie('theme', 'dark');
+  const [term, setTerm] = useCookie('term');
+  const [termData, patchTermData] = useJsonCookie(term, defaultTermData);
 
+  // Memoize context values so that their references are stable
   const themeContextValue = useMemo(() => [theme, setTheme], [theme, setTheme]);
-
   const termsContextValue = useMemo(() => [terms, setTerms], [terms, setTerms]);
-
   const termContextValue = useMemo(
     () => [
       { term, oscar, ...termData },
@@ -50,39 +37,39 @@ export function App(props) {
     [term, oscar, termData, setTerm, setOscar, patchTermData]
   );
 
-  const overlayContextValue = useMemo(() => [overlayCrns, setOverlayCrns], [
-    overlayCrns,
-    setOverlayCrns
-  ]);
-
+  // Fetch the current term's scraper information
   useEffect(() => {
     setOscar(null);
     if (term) {
       axios
         .get(`https://gtbitsofgood.github.io/gt-schedule-crawler/${term}.json`)
         .then((res) => {
-          const oscar = new Oscar(res.data);
-          setOscar(oscar);
+          const newOscar = new Oscar(res.data);
+          setOscar(newOscar);
         });
     }
   }, [term]);
 
+  // Fetch all terms via the GitHub API
+  // TODO change to Bits of Good repo to fetch up-to-date terms
   useEffect(() => {
     axios
       .get(
         'https://api.github.com/repos/64json/gt-schedule-crawler/contents?ref=gh-pages'
       )
       .then((res) => {
-        const terms = res.data
+        const newTerms = res.data
           .map((content) => content.name)
           .filter((name) => /\d{6}\.json/.test(name))
           .map((name) => name.replace(/\.json$/, ''))
           .sort()
           .reverse();
-        setTerms(terms);
+        setTerms(newTerms);
       });
-  }, [setTerms]);
+  });
 
+  // Set the term to be the first one if it is unset
+  // (once the terms load)
   useEffect(() => {
     if (!term) {
       const [recentTerm] = terms;
@@ -90,21 +77,16 @@ export function App(props) {
     }
   }, [terms, term, setTerm]);
 
-  useEffect(() => {
-    const handleResize = (e) => {
-      const newMobile = isMobile();
-      if (mobile !== newMobile) {
-        setMobile(newMobile);
-      }
-    };
-    window.addEventListener('resize', handleResize);
-    return () => {
-      window.removeEventListener('resize', handleResize);
-    };
-  }, [mobile]);
-
+  // Re-render when the page is re-sized to become mobile/desktop
+  // (desktop is >= 1024 px wide)
+  const mobile = useMobile();
   const className = classes('App', mobile && 'mobile', theme);
 
+  // Allow top-level tab-based navigation
+  const [currentTabIndex, setTabIndex] = useState(0);
+
+  // If the scraped JSON hasn't been loaded,
+  // then show an empty div as a loading intermediate
   if (!oscar) {
     return <div className={className} />;
   }
@@ -113,37 +95,22 @@ export function App(props) {
     <ThemeContext.Provider value={themeContextValue}>
       <TermsContext.Provider value={termsContextValue}>
         <TermContext.Provider value={termContextValue}>
-          <OverlayCrnsContext.Provider value={overlayContextValue}>
-            <div className={className}>
-              <Header />
-              {mobile && (
-                <div className="tab-container">
-                  {['Courses', 'Combinations', 'Calendar'].map(
-                    (tabTitle, i) => (
-                      <Button
-                        key={tabTitle}
-                        className={classes('tab', tabIndex === i && 'active')}
-                        onClick={() => setTabIndex(i)}
-                      >
-                        {tabTitle}
-                      </Button>
-                    )
-                  )}
-                </div>
-              )}
-              <div className="main">
-                {(!mobile || tabIndex === 0) && <CourseContainer />}
-                {(!mobile || tabIndex === 1) && <CombinationContainer />}
-                {(!mobile || tabIndex === 2) && (
-                  <div className="calendar-container">
-                    <Calendar className="calendar" overlayCrns={overlayCrns} />
-                  </div>
-                )}
-              </div>
-            </div>
-          </OverlayCrnsContext.Provider>
+          <div className={className}>
+            {/* The header controls top-level navigation
+            and is always present */}
+            <Header
+              currentTab={currentTabIndex}
+              onChangeTab={setTabIndex}
+              tabs={['Scheduler', 'Map', 'Comparison']}
+            />
+            {currentTabIndex === 0 && <Scheduler />}
+            {currentTabIndex === 1 && <Map />}
+            {currentTabIndex === 2 && <Comparison />}
+          </div>
         </TermContext.Provider>
       </TermsContext.Provider>
     </ThemeContext.Provider>
   );
-}
+};
+
+export default App;

--- a/src/components/Comparison/index.js
+++ b/src/components/Comparison/index.js
@@ -1,0 +1,8 @@
+import React from 'react';
+
+const Comparison = () => {
+  // TODO implement
+  return <>Not yet implemented</>;
+};
+
+export default Comparison;

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useContext, useMemo, useRef } from 'react';
-import { getSemesterName } from '../../utils';
+import PropTypes from 'prop-types';
 import 'react-virtualized/styles.css';
 import './stylesheet.scss';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -13,12 +13,17 @@ import { faGithub } from '@fortawesome/free-brands-svg-icons';
 import Cookies from 'js-cookie';
 import domtoimage from 'dom-to-image';
 import saveAs from 'file-saver';
+import { getSemesterName } from '../../utils';
 import { PNG_SCALE_FACTOR } from '../../constants';
 import ics from '../../libs/ics';
-import { Button, Calendar, Select } from '..';
+import { Button, Calendar, Select, Tab } from '..';
 import { TermContext, TermsContext, ThemeContext } from '../../contexts';
 
-export function Header(props) {
+/**
+ * Renders the top header component,
+ * and includes controls for top-level tab-based navigation
+ */
+const Header = ({ currentTab, onChangeTab, tabs }) => {
   const [{ term, oscar, pinnedCrns }, { setTerm }] = useContext(TermContext);
   const [terms] = useContext(TermsContext);
   const [theme, setTheme] = useContext(ThemeContext);
@@ -54,12 +59,9 @@ export function Header(props) {
         ) {
           begin.setDate(begin.getDate() + 1);
         }
-        begin.setHours(
-          (meeting.period.start / 60) | 0,
-          meeting.period.start % 60
-        );
+        begin.setHours(meeting.period.start / 60, meeting.period.start % 60);
         const end = new Date(begin.getTime());
-        end.setHours((meeting.period.end / 60) | 0, meeting.period.end % 60);
+        end.setHours(meeting.period.end / 60, meeting.period.end % 60);
         const rrule = {
           freq: 'WEEKLY',
           until: to,
@@ -97,13 +99,26 @@ export function Header(props) {
       <Select
         onChange={setTerm}
         value={term}
-        options={terms.map((term) => ({
-          value: term,
-          label: getSemesterName(term)
+        options={terms.map((currentTerm) => ({
+          value: currentTerm,
+          label: getSemesterName(currentTerm)
         }))}
         className="semester"
       />
       <span className="credits">{totalCredits} Credits</span>
+
+      {/* Include middle-aligned tabs on desktop
+      TODO change display on mobile screens */}
+      <div className="tabs">
+        {tabs.map((tabLabel, tabIdx) => (
+          <Tab
+            active={tabIdx === currentTab}
+            onClick={() => onChangeTab(tabIdx)}
+            label={tabLabel}
+          />
+        ))}
+      </div>
+
       <div className="menu">
         <Button onClick={handleDownload} disabled={pinnedCrns.length === 0}>
           <FontAwesomeIcon className="icon" fixedWidth icon={faDownload} />
@@ -131,4 +146,12 @@ export function Header(props) {
       </div>
     </div>
   );
-}
+};
+
+Header.propTypes = {
+  currentTab: PropTypes.number.isRequired,
+  onChangeTab: PropTypes.func.isRequired,
+  tabs: PropTypes.arrayOf(PropTypes.string).isRequired
+};
+
+export default Header;

--- a/src/components/Header/stylesheet.scss
+++ b/src/components/Header/stylesheet.scss
@@ -20,6 +20,15 @@
     }
   }
 
+  .tabs {
+    display: flex;
+    flex-direction: row;
+    margin-left: auto;
+    margin-right: auto;
+    align-items: center;
+    justify-content: center;
+  }
+
   .semester {
   }
 
@@ -32,7 +41,6 @@
   .menu {
     display: flex;
     align-items: stretch;
-    margin-left: auto;
 
     .text {
       margin-left: 4px;

--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -1,0 +1,8 @@
+import React from 'react';
+
+const Map = () => {
+  // TODO implement
+  return <>Not yet implemented</>;
+};
+
+export default Map;

--- a/src/components/Scheduler/index.js
+++ b/src/components/Scheduler/index.js
@@ -1,0 +1,55 @@
+import React, { useMemo, useState } from 'react';
+import { classes } from '../../utils';
+import { Button, Calendar, CombinationContainer, CourseContainer } from '..';
+import { OverlayCrnsContext } from '../../contexts';
+import { useMobile } from '../../hooks';
+
+/**
+ * Wraps around the root top-level component of the Scheduler tab
+ */
+const Scheduler = () => {
+  const mobile = useMobile();
+
+  // Store the current set of CRNs that are shown on the Calendar overlay
+  const [overlayCrns, setOverlayCrns] = useState([]);
+
+  // Control second-level navigation between panes on mobile
+  const [tabIndex, setTabIndex] = useState(0);
+
+  // Memoize the CRN overlay set's context value so it is stable
+  const overlayContextValue = useMemo(() => [overlayCrns, setOverlayCrns], [
+    overlayCrns,
+    setOverlayCrns
+  ]);
+
+  return (
+    <>
+      {mobile && (
+        <div className="tab-container">
+          {['Courses', 'Combinations', 'Calendar'].map((tabTitle, i) => (
+            <Button
+              key={tabTitle}
+              className={classes('tab', tabIndex === i && 'active')}
+              onClick={() => setTabIndex(i)}
+            >
+              {tabTitle}
+            </Button>
+          ))}
+        </div>
+      )}
+      <OverlayCrnsContext.Provider value={overlayContextValue}>
+        <div className="main">
+          {(!mobile || tabIndex === 0) && <CourseContainer />}
+          {(!mobile || tabIndex === 1) && <CombinationContainer />}
+          {(!mobile || tabIndex === 2) && (
+            <div className="calendar-container">
+              <Calendar className="calendar" overlayCrns={overlayCrns} />
+            </div>
+          )}
+        </div>
+      </OverlayCrnsContext.Provider>
+    </>
+  );
+};
+
+export default Scheduler;

--- a/src/components/Tab/index.js
+++ b/src/components/Tab/index.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { classes } from '../../utils';
+
+import './stylesheet.scss';
+
+const Tab = ({ label, active, onClick, className, style }) => (
+  <button
+    className={classes('Tab', active && 'active', className)}
+    style={style}
+    onClick={onClick}
+    type="button"
+  >
+    {label}
+  </button>
+);
+
+Tab.propTypes = {
+  label: PropTypes.string.isRequired,
+  active: PropTypes.bool,
+  onClick: PropTypes.func.isRequired,
+  className: PropTypes.string,
+  // eslint-disable-next-line react/forbid-prop-types
+  style: PropTypes.object
+};
+
+Tab.defaultProps = {
+  active: false,
+  className: '',
+  style: {}
+};
+
+export default Tab;

--- a/src/components/Tab/stylesheet.scss
+++ b/src/components/Tab/stylesheet.scss
@@ -1,0 +1,29 @@
+@import '../../variables';
+
+.Tab {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 12px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  background-color: transparent;
+  outline: none;
+  border: none;
+
+  border-bottom: 2px solid transparent;
+
+  &.active {
+    // TODO make these actual accent colors
+    color: currentColor;
+    border-bottom-color: currentColor;
+  }
+
+  &:not(.active) {
+    color: $color-neutral;
+  }
+
+  &:hover {
+    background-color: $color-border;
+  }
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,16 +1,21 @@
+/* eslint-disable import/no-cycle */
 export * from './ActionRow';
-export * from './App';
+export { default as App } from './App';
 export * from './Button';
 export * from './Calendar';
 export * from './CombinationContainer';
+export { default as Comparison } from './Comparison';
 export * from './Course';
 export * from './CourseAdd';
 export * from './CourseContainer';
 export * from './CourseFilter';
-export * from './Header';
+export { default as Header } from './Header';
 export * from './Instructor';
+export { default as Map } from './Map';
 export * from './Palette';
+export { default as Scheduler } from './Scheduler';
 export * from './Section';
 export * from './Select';
+export { default as Tab } from './Tab';
 export * from './TimeBlocks';
 export * from './Prerequisite';

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,2 +1,4 @@
+/* eslint-disable import/no-cycle */
 export * from './useCookie';
 export * from './useJsonCookie';
+export { default as useMobile } from './useMobile';

--- a/src/hooks/useMobile.js
+++ b/src/hooks/useMobile.js
@@ -1,0 +1,26 @@
+import { useState, useEffect } from 'react';
+import { isMobile } from '../utils';
+
+/**
+ * Subscribes to resize events on the page
+ *
+ * ? Would this be better to subscribe to a media query ?
+ */
+export default function useMobile() {
+  const [mobile, setMobile] = useState(isMobile());
+  useEffect(() => {
+    const handleResize = () => {
+      const newMobile = isMobile();
+      if (mobile !== newMobile) {
+        setMobile(newMobile);
+      }
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, [mobile]);
+
+  return mobile;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { App } from './components/App';
+import App from './components/App';
 import 'normalize.css';
 import './stylesheet.scss';
 


### PR DESCRIPTION
### Changes

- Adds top-level tabs using `Tab` component:

  ![Scheduler tab](https://i.imgur.com/t4gRjEx.png)

  ![Map tab](https://i.imgur.com/2C5APb5.png)

- Adds `prop-types` to the dependencies to document added prop types (and satisfy linter)
  - If we're going to go ahead and now require prop types, should we instead consider incrementally starting to use TypeScript (i.e. new files would be written in TS)?
- Adds comments to the App component
- Splits App component into `Scheduler`, `Map`, and `Comparison` components that contain the main content of each top-level view
- Fixes bug with GitHub API pointing to the wrong URL
